### PR TITLE
Implement the rest of the AutoTags API

### DIFF
--- a/api/autotags.go
+++ b/api/autotags.go
@@ -129,3 +129,30 @@ func (s *autoTagsService) ValidateUpdate(ID string, autoTag AutoTag) (*Error, *r
 	return nil, apiResponse, StatusError(apiResponse.StatusCode())
 
 }
+
+func (s *autoTagsService) ValidateCreate(autoTag AutoTag) (*Error, *resty.Response, error) {
+
+	validatorResp := new(Error)
+
+	apiResponse, err := s.client.Do("POST", "/api/config/v1/autoTags/", autoTag, nil)
+
+	if apiResponse.StatusCode() == 400 {
+
+		unmarshalError := json.Unmarshal(apiResponse.Body(), validatorResp)
+		if unmarshalError != nil {
+			return nil, apiResponse, unmarshalError
+		}
+		return validatorResp, apiResponse, nil
+	}
+
+	if apiResponse.StatusCode()/100 == 2 {
+		return nil, apiResponse, nil
+	}
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nil, apiResponse, StatusError(apiResponse.StatusCode())
+
+}

--- a/api/autotags.go
+++ b/api/autotags.go
@@ -8,6 +8,7 @@ import (
 
 type autoTagsService service
 
+// GetAll lists all configured auto tags
 func (s *autoTagsService) GetAll() ([]AutoTag, *resty.Response, error) {
 
 	autoTags := new(AutoTagResponse)
@@ -26,6 +27,7 @@ func (s *autoTagsService) GetAll() ([]AutoTag, *resty.Response, error) {
 
 }
 
+// Create creates a new auto tag
 func (s *autoTagsService) Create(autoTag AutoTag) (*AutoTag, *resty.Response, error) {
 	autoTagResp := new(AutoTag)
 
@@ -43,6 +45,7 @@ func (s *autoTagsService) Create(autoTag AutoTag) (*AutoTag, *resty.Response, er
 
 }
 
+// Get gets the properties of the specified auto tag
 func (s *autoTagsService) Get(ID string, includeProcessGroupReferences bool) (*AutoTag, *resty.Response, error) {
 
 	autoTag := new(AutoTag)
@@ -63,6 +66,7 @@ func (s *autoTagsService) Get(ID string, includeProcessGroupReferences bool) (*A
 
 }
 
+// Update updates an existing auto tag or creates a new one
 func (s *autoTagsService) Update(ID string, autoTag AutoTag) (*AutoTag, *resty.Response, error) {
 	autoTagResp := new(AutoTag)
 
@@ -85,6 +89,7 @@ func (s *autoTagsService) Update(ID string, autoTag AutoTag) (*AutoTag, *resty.R
 
 }
 
+// Delete deletes the specified auto tag
 func (s *autoTagsService) Delete(ID string) (*resty.Response, error) {
 
 	url := fmt.Sprintf("/api/config/v1/autoTags/%s", ID)
@@ -102,6 +107,7 @@ func (s *autoTagsService) Delete(ID string) (*resty.Response, error) {
 
 }
 
+// ValidateUpdate validates update of existing auto tags for the `PUT /autoTags/{id}` request
 func (s *autoTagsService) ValidateUpdate(ID string, autoTag AutoTag) (*Error, *resty.Response, error) {
 
 	validatorResp := new(Error)
@@ -130,6 +136,7 @@ func (s *autoTagsService) ValidateUpdate(ID string, autoTag AutoTag) (*Error, *r
 
 }
 
+// ValidateCreate validates new auto tags for the `POST /autoTags` request
 func (s *autoTagsService) ValidateCreate(autoTag AutoTag) (*Error, *resty.Response, error) {
 
 	validatorResp := new(Error)

--- a/api/autotags.go
+++ b/api/autotags.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"fmt"
 	"gopkg.in/resty.v1"
 )
@@ -108,20 +107,14 @@ func (s *autoTagsService) Delete(ID string) (*resty.Response, error) {
 }
 
 // ValidateUpdate validates update of existing auto tags for the `PUT /autoTags/{id}` request
-func (s *autoTagsService) ValidateUpdate(ID string, autoTag AutoTag) (*Error, *resty.Response, error) {
+func (s *autoTagsService) ValidateUpdate(ID string, autoTag AutoTag) (*ErrorDetail, *resty.Response, error) {
 
-	validatorResp := new(Error)
 	url := fmt.Sprintf("/api/config/v1/autoTags/%s/validator", ID)
 
 	apiResponse, err := s.client.Do("POST", url, autoTag, nil)
 
 	if apiResponse.StatusCode() == 400 {
-
-		unmarshalError := json.Unmarshal(apiResponse.Body(), validatorResp)
-		if unmarshalError != nil {
-			return nil, apiResponse, unmarshalError
-		}
-		return validatorResp, apiResponse, nil
+		return apiResponse.Error().(*ErrorResponse).Detail, apiResponse, err
 	}
 
 	if apiResponse.StatusCode()/100 == 2 {
@@ -137,19 +130,12 @@ func (s *autoTagsService) ValidateUpdate(ID string, autoTag AutoTag) (*Error, *r
 }
 
 // ValidateCreate validates new auto tags for the `POST /autoTags` request
-func (s *autoTagsService) ValidateCreate(autoTag AutoTag) (*Error, *resty.Response, error) {
-
-	validatorResp := new(Error)
+func (s *autoTagsService) ValidateCreate(autoTag AutoTag) (*ErrorDetail, *resty.Response, error) {
 
 	apiResponse, err := s.client.Do("POST", "/api/config/v1/autoTags/", autoTag, nil)
 
 	if apiResponse.StatusCode() == 400 {
-
-		unmarshalError := json.Unmarshal(apiResponse.Body(), validatorResp)
-		if unmarshalError != nil {
-			return nil, apiResponse, unmarshalError
-		}
-		return validatorResp, apiResponse, nil
+		return apiResponse.Error().(*ErrorResponse).Detail, apiResponse, err
 	}
 
 	if apiResponse.StatusCode()/100 == 2 {

--- a/api/autotags.go
+++ b/api/autotags.go
@@ -83,3 +83,20 @@ func (s *autoTagsService) Update(ID string, autoTag AutoTag) (*AutoTag, *resty.R
 	return nil, apiResponse, StatusError(apiResponse.StatusCode())
 
 }
+
+func (s *autoTagsService) Delete(ID string) (*resty.Response, error) {
+
+	url := fmt.Sprintf("/api/config/v1/autoTags/%s", ID)
+	apiResponse, err := s.client.Do("DELETE", url, nil, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if apiResponse.StatusCode()/100 == 2 {
+		return apiResponse, nil
+	}
+
+	return apiResponse, StatusError(apiResponse.StatusCode())
+
+}

--- a/api/autotags.go
+++ b/api/autotags.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"gopkg.in/resty.v1"
 )
@@ -98,5 +99,33 @@ func (s *autoTagsService) Delete(ID string) (*resty.Response, error) {
 	}
 
 	return apiResponse, StatusError(apiResponse.StatusCode())
+
+}
+
+func (s *autoTagsService) ValidateUpdate(ID string, autoTag AutoTag) (*Error, *resty.Response, error) {
+
+	validatorResp := new(Error)
+	url := fmt.Sprintf("/api/config/v1/autoTags/%s/validator", ID)
+
+	apiResponse, err := s.client.Do("POST", url, autoTag, nil)
+
+	if apiResponse.StatusCode() == 400 {
+
+		unmarshalError := json.Unmarshal(apiResponse.Body(), validatorResp)
+		if unmarshalError != nil {
+			return nil, apiResponse, unmarshalError
+		}
+		return validatorResp, apiResponse, nil
+	}
+
+	if apiResponse.StatusCode()/100 == 2 {
+		return nil, apiResponse, nil
+	}
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nil, apiResponse, StatusError(apiResponse.StatusCode())
 
 }

--- a/api/types.go
+++ b/api/types.go
@@ -87,13 +87,29 @@ type AutoTagRuleCondition struct {
 	ComparisonInfo AutoTagRuleConditionComparisonInfo `json:"comparisonInfo"`
 }
 
+type ConstraintViolation struct {
+	Path              string                               `json:"path,omitempty"`
+	Message           string                               `json:"message,omitempty"`
+	ParameterLocation ConstraintViolationParameterLocation `json:"parameterLocation,omitempty"`
+	Location          string                               `json:"location,omitempty"`
+}
+
+type ConstraintViolationParameterLocation string
+
+const (
+	ConstraintViolationParameterLocationPath        ConstraintViolationParameterLocation = "PATH"
+	ConstraintViolationParameterLocationPayloadBody ConstraintViolationParameterLocation = "PAYLOAD_BODY"
+	ConstraintViolationParameterLocationQuery       ConstraintViolationParameterLocation = "QUERY"
+)
+
 type ErrorResponse struct {
 	Detail *ErrorDetail `json:"error,omitempty"`
 }
 
 type ErrorDetail struct {
-	Code    int64  `json:"code,omitempty"`
-	Message string `json:"message,omitempty"`
+	Code                 int64                 `json:"code,omitempty"`
+	Message              string                `json:"message,omitempty"`
+	ConstraintViolations []ConstraintViolation `json:"constraintViolations"`
 }
 
 func (e *ErrorResponse) Error() string {

--- a/api/types.go
+++ b/api/types.go
@@ -88,6 +88,11 @@ type AutoTagRuleCondition struct {
 }
 
 // Error Structs
+
+type Error struct {
+	Error ErrorEnvelop `json:"error"`
+}
+
 type ErrorEnvelop struct {
 	Code                 int                   `json:"code"`
 	Message              string                `json:"message"`

--- a/api/types.go
+++ b/api/types.go
@@ -54,10 +54,10 @@ type AutoTagRule struct {
 type AutoTagRuleType string
 
 const (
-	CustomDevice AutoTagRuleType = "CUSTOM_DEVICE"
-	Host                         = "HOST"
-	ProcessGroup                 = "PROCESS_GROUP"
-	Service                      = "SERVICE"
+	AutoTagRuleTypeCustomDevice AutoTagRuleType = "CUSTOM_DEVICE"
+	AutoTagRuleTypeHost                         = "HOST"
+	AutoTagRuleTypeProcessGroup                 = "PROCESS_GROUP"
+	AutoTagRuleTypeService                      = "SERVICE"
 )
 
 type AutoTagRulePropagationType string

--- a/api/types.go
+++ b/api/types.go
@@ -54,10 +54,10 @@ type AutoTagRule struct {
 type AutoTagRuleType string
 
 const (
-	CustomDevice AutoTagRuleType = "CUSTOM_DEVICE"
-	Host                         = "HOST"
-	ProcessGroup                 = "PROCESS_GROUP"
-	Service                      = "SERVICE"
+	AutoTagRuleTypeCustomDevice AutoTagRuleType = "CUSTOM_DEVICE"
+	AutoTagRuleTypeHost                         = "HOST"
+	AutoTagRuleTypeProcessGroup                 = "PROCESS_GROUP"
+	AutoTagRuleTypeService                      = "SERVICE"
 )
 
 type AutoTagRulePropagationType string
@@ -85,4 +85,26 @@ type AutoTagRuleConditionComparisonInfo struct {
 type AutoTagRuleCondition struct {
 	Key            AutoTagRuleConditionKey            `json:"key"`
 	ComparisonInfo AutoTagRuleConditionComparisonInfo `json:"comparisonInfo"`
+}
+
+// Error Structs
+type ErrorEnvelop struct {
+	Code                 int                   `json:"code"`
+	Message              string                `json:"message"`
+	ConstraintViolations []ConstraintViolation `json:"constraintViolations"`
+}
+
+type ParameterLocation string
+
+const (
+	ParameterLocationPath        ParameterLocation = "PATH"
+	ParameterLocationPayloadBody                   = "PAYLOAD_BODY"
+	ParameterLocationQuery                         = "QUERY"
+)
+
+type ConstraintViolation struct {
+	Path              string            `json:"path"`
+	Message           string            `json:"message"`
+	ParameterLocation ParameterLocation `json:"parameterLocation"`
+	Location          string            `json:"location"`
 }

--- a/examples/autotags/autotags_example.go
+++ b/examples/autotags/autotags_example.go
@@ -64,7 +64,7 @@ func updateAutoTag() {
 	fmt.Println("\nUpdating a single AutoTag...")
 
 	autoTags, _, _ := c.AutoTags.GetAll()
-	autoTag, _, _ := c.AutoTags.Get(autoTags[2].ID, false)
+	autoTag, _, _ := c.AutoTags.Get(autoTags[0].ID, false)
 
 	autoTag.Rules[0].Conditions[0].ComparisonInfo.Value = "New Comparison"
 
@@ -74,8 +74,20 @@ func updateAutoTag() {
 
 }
 
+func deleteAutoTag() {
+
+	fmt.Println("\nDeleting an AutoTag...")
+	autoTags, _, _ := c.AutoTags.GetAll()
+
+	resp, err := c.AutoTags.Delete(autoTags[0].ID)
+	fmt.Println(resp.StatusCode())
+	fmt.Println("Error", err)
+
+}
+
 func main() {
 	createNewAutoTag()
 	getAutoTagDetails()
 	updateAutoTag()
+	deleteAutoTag()
 }

--- a/examples/autotags/autotags_example.go
+++ b/examples/autotags/autotags_example.go
@@ -85,9 +85,25 @@ func deleteAutoTag() {
 
 }
 
+func validadeUpdate() {
+	fmt.Println("\nValidating update...")
+	autoTags, _, _ := c.AutoTags.GetAll()
+
+	autoTagToValidate, _, _ := c.AutoTags.Get(autoTags[0].ID, false)
+	autoTagToValidate.Rules[0].Conditions[0].ComparisonInfo.Negate = true
+
+	validated, resp, err := c.AutoTags.ValidateUpdate(autoTagToValidate.ID, *autoTagToValidate)
+	fmt.Println("Validated", validated)
+	fmt.Println("resp", resp.StatusCode())
+	fmt.Println("err", err)
+
+}
+
 func main() {
 	createNewAutoTag()
 	getAutoTagDetails()
+	validadeUpdate()
 	updateAutoTag()
 	deleteAutoTag()
+
 }

--- a/examples/autotags/autotags_example.go
+++ b/examples/autotags/autotags_example.go
@@ -30,7 +30,7 @@ func createNewAutoTag() {
 
 	rules := []dynatrace.AutoTagRule{
 		{
-			Type:        dynatrace.CustomDevice,
+			Type:        dynatrace.AutoTagRuleTypeCustomDevice,
 			Enabled:     true,
 			ValueFormat: "Test {CustomDevice:DetectedName}",
 			Conditions:  []dynatrace.AutoTagRuleCondition{condition},

--- a/examples/autotags/autotags_example.go
+++ b/examples/autotags/autotags_example.go
@@ -6,8 +6,8 @@ import (
 )
 
 var c = dynatrace.New(dynatrace.Config{
-	APIKey:  "MyAPIKey",
-	BaseURL: "https://my.tenant.url/",
+	APIKey:  "WqtGxyF1Qzah2UjuW8q02",
+	BaseURL: "https://eaa50379.sprint.dynatracelabs.com",
 })
 
 func createNewAutoTag() {
@@ -93,7 +93,7 @@ func validadeUpdate() {
 	autoTagToValidate.Rules[0].Conditions[0].ComparisonInfo.Negate = true
 
 	validated, resp, err := c.AutoTags.ValidateUpdate(autoTagToValidate.ID, *autoTagToValidate)
-	fmt.Println("Validated", validated)
+	fmt.Println("Validated", validated.ConstraintViolations)
 	fmt.Println("resp", resp.StatusCode())
 	fmt.Println("err", err)
 

--- a/examples/autotags/autotags_example.go
+++ b/examples/autotags/autotags_example.go
@@ -99,9 +99,25 @@ func validadeUpdate() {
 
 }
 
+func validateCreate() {
+
+	fmt.Println("\nValidating create...")
+	autoTags, _, _ := c.AutoTags.GetAll()
+
+	autoTagToValidate, _, _ := c.AutoTags.Get(autoTags[0].ID, false)
+	autoTagToValidate.Rules[0].Conditions[0].ComparisonInfo.Negate = true
+
+	validated, resp, err := c.AutoTags.ValidateCreate(*autoTagToValidate)
+	fmt.Println("Validated", validated)
+	fmt.Println("resp", resp.StatusCode())
+	fmt.Println("err", err)
+
+}
+
 func main() {
 	createNewAutoTag()
 	getAutoTagDetails()
+	validateCreate()
 	validadeUpdate()
 	updateAutoTag()
 	deleteAutoTag()


### PR DESCRIPTION
Fix #4 

This PR implements the rest of the AutoTags API.  
  
Note that for `Validator` calls, Dynatrace gives us valid responses as HTTP 400, so I had to unmarshal that as an array of bytes, and I did not want to modify client.go, let me know if that is too ugly.

Other than that, I have implemented the form `client.AutoTags.Method()`

I've also added an examples folder, please review if we are OK with that format (`examples/api/files.go`)

 